### PR TITLE
Update sql_stream_builder_lite.adoc

### DIFF
--- a/sql_stream_builder_lite.adoc
+++ b/sql_stream_builder_lite.adoc
@@ -92,6 +92,7 @@ Click on the *Transformations* tab and enter the following code in the *Code* fi
 // Kafka payload (record value JSON deserialized to JavaScript object)
 var payload = JSON.parse(record.value);
 payload['sensor_0'] = Math.round(payload.sensor_0 * 1000);
+payload['sensor_ts'] = Math.round(payload.sensor_ts / 1000);
 JSON.stringify(payload);
 ----
 +


### PR DESCRIPTION
added a line to the iot_enriched_source table transformation; if we don't do this the timestamps will be in the wrong format (= too large by a factor of 1000)