### PR TITLE
need to change the kudu table name

### DIFF
--- a/streaming_lite.adoc
+++ b/streaming_lite.adoc
@@ -393,7 +393,7 @@ Name: Write to Kudu
 [source]
 ----
 Kudu Masters:     edge2ai-0.dim.local:7051
-Table Name:       impala::default.sensors
+Table Name:       default.sensors
 Record Reader:    JsonTreeReader - With schema identifier
 ----
 


### PR DESCRIPTION
impala::default.sensors doesn't seem to work (anymore?)
just giving the table name 'default.sensors' fixes it.